### PR TITLE
Scripts to generate a dataset file list

### DIFF
--- a/code/add_file_urls.py
+++ b/code/add_file_urls.py
@@ -1,0 +1,41 @@
+from argparse import ArgumentParser
+import csv
+from pathlib import Path
+from html import escape
+
+# Source: https://github.com/abcd-j/data-catalog/issues/22
+# Currently a custom script for the gliem_pavic dataset
+# How can we generalise this?
+
+url_root = 'https://www.ncbi.nlm.nih.gov/geo/download/'
+fieldnames = ['path[POSIX]', 'size[bytes]', 'checksum[md5]', 'url']
+
+if __name__ == "__main__":
+    # Argument parsing and validation
+    parser = ArgumentParser()
+    parser.add_argument(
+        "file_path", type=str, help="Path to file with filelist",
+    )    
+    parser.add_argument(
+        "out_path", type=str, help="Path to output file",
+    )    
+    args = parser.parse_args()    
+
+    with open(Path(args.file_path), encoding='utf8', newline='') as file:
+        reader = csv.DictReader(file, delimiter='\t')
+        out_rows = []
+        for row in reader:
+            filename = Path(row['path[POSIX]']).name
+            fparts = filename.split('_')
+            file_id = fparts[0]
+            row['url'] = f"{url_root}?acc={file_id}&format=file&file={escape(filename)}"
+            out_rows.append(row)    
+    
+    with open(Path(args.out_path), 'w', encoding='utf8', newline='') as output_file:
+            fc = csv.DictWriter(
+                output_file,
+                fieldnames=fieldnames,
+                delimiter='\t'
+            )
+            fc.writerow(dict((fn,fn) for fn in fieldnames))
+            fc.writerows(out_rows)

--- a/code/create_tabby_filelist.py
+++ b/code/create_tabby_filelist.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Print a table with information about the files contained in
+a directory on a filesystem or a git repository or a datalad dataset.
+File information is compliant with the tabby convention for a collection-of-files dataset
+(see: https://docs.datalad.org/projects/tabby/en/latest/conventions/tby-ds1.html)
+and includes:
+    - the file path (column: path[POSIX])
+    - the file content checksum, using the md5 hash algorithm (column: checksum[md5])
+    - the file size in bytes (column: size[bytes])
+    - the empty file url (column: url)
+
+The output table can be printed to STDOUT or to a text file in TSV format.
+"""
+import os
+from pathlib import Path
+import argparse
+import hashlib
+import csv
+
+
+def create_filetable(
+    rootpath: str,
+    method: str = 'tree',
+    hash: str = 'md5',
+    recursive: bool = True,
+    output: str = 'stdout',
+):
+    """
+    Print a table with information about the files contained in
+    a directory on a filesystem.
+
+    Args:
+        rootpath (str): The root directory for which the table 
+            should be printed.
+        
+        hash (str, optional): Name of the algorithm to be used for
+            calculating file hashes, e.g. 'md5' or 'sha256'. The
+            algorithm must be supported by the Python 'hashlib' module.
+            Defaults to 'md5'.
+        
+        recursive (bool, optional): Set this flag to recurse into
+            subdirectories. Defaults to False.
+
+        output (str, optional): A directory of filename to save the
+            output to. Defaults to 'stdout.
+    """
+    # Get file list
+    out_info = []
+
+    if method == 'tree':
+        _tree2filelist(Path(rootpath).resolve(), out_info)
+    else:
+        _dir2filelist(Path(rootpath), Path(rootpath), out_info, hash, recursive)
+    # Output the data
+    # header compliant with tby-ds1 convention
+    header = {
+        'path': 'path[POSIX]',
+        'size': 'size[bytes]',
+        'hash': f'checksum[{hash}]',
+        'url': 'url'
+    }
+    fieldnames = out_info[0].keys()
+    headernames = [header[fn] for fn in fieldnames]
+    if output != 'stdout':
+        outpath = _get_output_path(output)
+        with open(outpath, 'w', encoding='utf8', newline='') as output_file:
+            fc = csv.DictWriter(
+                output_file,
+                fieldnames=fieldnames,
+                delimiter='\t'
+            )
+            fc.writerow(dict((fn,hn) for (fn,hn) in zip(fieldnames, headernames)))
+            fc.writerows(out_info)
+        print(f'Output saved to: {outpath.absolute()}')
+    else:
+        print(f'{header["hash"]}\t{header["size"]}\t{header["path"]}\t{header["url"]}')
+        for el in out_info:
+            print(f'{el["hash"]}\t{el["size"]}\t{el["path"]}\t')
+
+
+def _dir2filelist(
+    rootpath: Path,
+    relpath: Path,
+    result: list,
+    hash: str = 'md5',
+    recursive: bool = True,
+):
+    """"""
+    if relpath is None:
+        relpath=rootpath
+    for f in relpath.glob('*'):
+        if f.is_file():
+            f_info = get_file_info(rp=rootpath,
+                                   fp=f,
+                                   hash_algo=hash)
+            result.append(f_info)                
+        elif f.is_dir():
+            if recursive:
+                _dir2filelist(rootpath, f, result, hash, recursive)
+        else:
+            # what to do here?
+            pass
+    return
+
+
+def get_file_info(rp: Path, fp: Path, hash_algo: str = 'md5'):
+    """
+    Returns a dict with path, checksum, and size in bytes
+    of a Path object (path is relative to a root Path)
+    """
+    with open(fp, "rb") as f:
+        hashclass = getattr(hashlib, hash_algo)
+        h = hashlib.file_digest(f, hashclass)
+    stats = os.stat(str(fp))
+    return dict(path=fp.relative_to(rp),
+                size=stats.st_size,
+                hash=h.hexdigest(),
+                url='',
+    )
+
+
+def _get_output_path(out_str):
+    """
+    Creates Path object from the provided output string with a filename
+    compliant with the tabby convention for a collection-of-files dataset (see: 
+    https://docs.datalad.org/projects/tabby/en/latest/conventions/tby-ds1.html)
+
+    If an existing directory is provided, the output filename will be
+    'files@tby-ds1.tsv', saved to the provided directory. If not, the provided
+    path will be interpreted as a filename, from which the prefix will be
+    derived, which is then prepended to '_files@tby-ds1.tsv' to form the output
+    filename.
+    """
+    outpath = Path(out_str)
+    if outpath.is_dir():
+        output_path = outpath / 'files@tby-ds1.tsv'
+    else:
+        # isolate prefix, without extension/suffix and without
+        # TODO: remove any redundancies in prefix e.g. if user
+        # provided an output filename already containing tby-ds1
+        # convention specification
+        prefix = outpath.stem
+        output_path = outpath.parent / f'{prefix}_files@tby-ds1.tsv'
+    # return tby-ds1 compliant file sheet name
+    return output_path
+
+
+def _tree2filelist(
+    rootpath: Path,
+    result: list,
+):
+    from datalad.api import tree
+    res = tree(
+        path=rootpath,
+        include_files=True,
+        return_type='generator'
+    )
+    for r in res:
+        fileinfo = _get_treenode_info(rootpath=rootpath, node=r)
+        if fileinfo:
+            result.append(fileinfo)
+
+
+def _get_treenode_info(rootpath: Path, node: dict):
+    tp = node.get('type')
+    # Only handle type = file
+    if tp == 'file':
+        fp = Path(node['path'])
+        symlink_target = node.get('symlink_target')
+        # if file is a symlink, get 
+        if symlink_target:
+            return _get_info_from_symlink_target(rp=rootpath, fp=fp, target=symlink_target)
+        else:
+            return get_file_info(rp=rootpath, fp=fp, hash_algo='md5')
+    else:
+        return None
+
+
+def _get_info_from_symlink_target(rp: Path, fp: Path, target: str):
+    stemparts = Path(target).stem.split('--')
+    return dict(
+        path=fp.relative_to(rp),
+        size=int(stemparts[0].replace('MD5E-s', '')),
+        hash=stemparts[1],
+        url='',
+    )
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "directory", metavar='PATH',
+        help="Directory for which a tabby file listing should be generated."
+    )
+    p.add_argument(
+        '--method', metavar='METHOD', default='glob',
+        help="Name of the method to be used for generating the list of files."
+        "Options include 'tree' (datalad tree), 'glob' (Path.glob), and more"
+        "methods to be added (ls-file-collection, others?). Default = 'glob'"
+    )
+    p.add_argument(
+        '--hash', metavar='HASH', default='md5',
+        help="Name of the algorithm to be used for calculating file hashes, "
+        "e.g. 'md5' or 'sha256'. The algorithm must be supported by the Python "
+        "'hashlib' module. Default = 'md5'"
+    )
+    p.add_argument(
+        '--non-recursive', action='store_true',
+        help="Do not recurse into subdirectories when generating a file listing "
+        "for a given root path. Default = False, i.e. recursion always happens "
+        "unless this flag is passed."
+    )
+    p.add_argument(
+        '--output', default='stdout',
+        help="Directory or filename to which the output should be saved. "
+        "If an existing directory is supplied, the file 'files@tby-ds1.tsv' "
+        "will be saved to that directory. "
+        "If a filename supplied, it will be used to derive the prefix which is "
+        "then prepended to '_files@tby-ds1.tsv' to form the filename at which the "
+        "output will be saved. "
+        "If this argument is not supplied, the output is printed to STDOUT"
+    )
+    args = p.parse_args()
+    create_filetable(
+        rootpath=args.directory,
+        method=args.method,
+        hash=args.hash,
+        recursive=not args.non_recursive,
+        output=args.output,
+    )

--- a/docs/source/for_maintainers.rst
+++ b/docs/source/for_maintainers.rst
@@ -1,0 +1,109 @@
+For maintainers
+***************
+
+This section covers instructions and descriptions of helper functionality
+for maintainers of the ABCD-J data catalog, or for users who have the necessary 
+technical expertise to contribute metadata to catalog themselves.
+
+
+The catalog setup
+=================
+
+.. note:: 
+    Coming soon! This section will explain the design of the ABCD-J catalog, 
+    how it is put together using different tools, and the requirements for 
+    maintaining or contributing to the catalog.
+
+
+Adding/updating catalog metadata
+================================
+
+.. note:: 
+    Coming soon! This section will explain how to use provided Python scripts to extract
+    and add new metadata to the ABCD-J catalog, or how to update existing metadata
+
+
+Generating a file list
+======================
+
+As mentioned in the user :doc:`instructions`, the optional ``files`` category lists
+one or more files that form part of the dataset, with recognized properties:
+
+* ``path[POSIX]`` (required)
+* ``size[bytes]`` (optional)
+* ``checksum[md5]`` (optional)
+* ``url`` (optional)
+
+While such a list of files can be created manually, this becomes tedious and time
+consuming for datasets with many files. It is possible to use scripts to automatically
+generate a full file list for a given dataset. Such scripts need to generate a TSV file
+with the recognized properties and in the format specified in the user :doc:`instructions`.
+
+Since datasets can be stored in different formats, hosted in different locations, and be accessed
+in different ways, it is unlikely that a single script can generalize a way in which to generate
+a file list. We supply a script ``create_tabby_filelist.py`` that currently supports two options
+via arguments:
+
+1. A folder with files, stored on local or server storage
+2. A DataLad dataset, stored on local or server storage
+
+.. note:: 
+    Customizations to support e.g. git repositories or compressed files are also possible
+
+Hence, it is firstly important to identify whether the script will be run on a
+DataLad dataset, or some files on a file system.
+
+Before running the scripts
+--------------------------
+
+First ensure that you have a recent version of Python on your machine.
+Then make sure you have the ``data-catalog`` code available locally:
+
+.. code-block:: bash
+
+   git clone https://github.com/abcd-j/data-catalog.git
+
+
+**For running the script on a folder with files**, you do not need to install any further
+requirements.
+
+**For running the script on a DataLad dataset**, please install requirements with ``pip``
+
+.. code-block:: bash
+   
+   cd data-catalog
+   pip install -r requirements.txt
+
+
+Running the scripts
+-------------------
+
+The `create_tabby_filelist.py`_ script can then be run as follows:
+
+.. code-block:: python
+   
+   python3 code/create_tabby_filelist.py --method <glob | tree> --output <path-to-output-directory> <path-to-dataset-location>
+
+where:
+
+* ``<glob | tree>`` should be the selected method: ``glob`` for a folder with files, or ``tree`` for a DataLad dataset
+* ``<path-to-output-directory>`` is where the TSV file named ``files@tby-ds1.tsv`` will be written to
+* ``<path-to-dataset-location>`` is the location of the dataset (folder with files or DataLad dataset)
+
+This will generate the correct TSV file at location ``<path-to-output-directory>/files@tby-ds1.tsv``, excluding the
+values for the ``url``.
+
+If your dataset has a specific download URL for each file, this can then be added to the TSV file.
+This process can be done manually, or with another script. Since URLs vary substantially, there is no
+general script that would be able to do this for any files. However, an example script can be
+found at `add_file_urls.py`_, which could be custimized to suit your own file url schema.
+
+
+.. _create_tabby_filelist.py: https://github.com/abcd-j/data-catalog/blob/main/code/create_tabby_filelist.py
+.. _add_file_urls.py: https://github.com/abcd-j/data-catalog/blob/main/code/add_file_urls.py
+
+
+
+
+
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ with step-wise instructions on how you can contribute data to the catalog.
 
    overview
    instructions
+   for_maintainers
 
 
 

--- a/docs/source/instructions.rst
+++ b/docs/source/instructions.rst
@@ -278,8 +278,9 @@ date
 ---------
 
 .. important::
-    For help with generating automatic filelists for your dataset,
-    please contact the ABCD-J support team at ``t.heunis@fz-juelich.de``.
+    For help with generating automatic filelists for your dataset, please see
+    the secion: :doc:`for_maintainers`. For further assistance, contact the ABCD-J
+    support team at ``t.heunis@fz-juelich.de``.
 
 This category lists one or more files that form part of the dataset.
 


### PR DESCRIPTION
This PR adds two scripts that serve to create file lists in the tabby format, which is in turn used by subsequent scripts to add file metadata to a catalog. The main script is `create_tabby_filelist.py`, which generalises the steps laid out in this issue: https://github.com/abcd-j/data-catalog/issues/22. The script can take an argument to specify in which way to generate a filelist, e.g. using `glob` for non-datalad datasets on a local filesystem, or `tree` which uses the `datalad tree` command for datalad datasets.

The second script is more of a custom script to add URLs to the filelist generated by the first script. These will be different for different datasets, but this specific script can serve as the basis for future changes that could perhaps be generalised over time.

The PR also includes a documentation update:
- Adds a "For maintainers" section to the docs
- Includes a description of how to use the added scripts to generate a file list

This PR can close https://github.com/abcd-j/data-catalog/issues/22.

